### PR TITLE
Update Topics page header

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -141,27 +141,43 @@ export async function decorateContent() {
   const { createTag, loadStyle } = await import(`${miloLibs}/utils/utils.js`);
   loadStyle(`${miloLibs}/blocks/figure/figure.css`);
 
-  imgEls.forEach((imgEl) => {
-    const block = createTag('div', { class: 'figure' });
-    const row = createTag('div');
-    const caption = getImageCaption(imgEl);
-    const parentEl = imgEl.closest('p');
-
-    if (!caption) {
-      const wrapper = createTag('div', null, imgEl.cloneNode(true));
-      row.append(wrapper);
-    } else {
-      const picture = createTag('p', null, imgEl.cloneNode(true));
-      const em = createTag('p', null, caption.cloneNode(true));
-      const wrapper = createTag('div');
-      wrapper.append(picture, em);
-      row.append(wrapper);
-      caption.remove();
-    }
-
-    block.append(row.cloneNode(true));
-    parentEl.replaceWith(block);
-  });
+  if (window.location.pathname.includes('/topics/')) {
+    /* 
+     * Topic pages have a unique page header.
+     * Transform it into a Milo marquee with a custom "mini" variant.
+    */
+    const parentEl = document.querySelector('main > div > p');
+    const imageEl = document.querySelector('main > div > p > picture');
+    const heading = document.querySelector('main > div > p + h1, main > div > p + h2');
+    const container = createTag('div', { class: 'marquee mini'});
+    const background = createTag('div', { class: 'background'}, imageEl);
+    const text = createTag('div', {}, heading);
+    const foreground = createTag('div', { class: 'foreground'}, text);
+    container.append(background, foreground);
+    parentEl.replaceWith(container);
+  } else {
+    imgEls.forEach((imgEl) => {
+      const block = createTag('div', { class: 'figure' });
+      const row = createTag('div');
+      const caption = getImageCaption(imgEl);
+      const parentEl = imgEl.closest('p');
+  
+      if (!caption) {
+        const wrapper = createTag('div', null, imgEl.cloneNode(true));
+        row.append(wrapper);
+      } else {
+        const picture = createTag('p', null, imgEl.cloneNode(true));
+        const em = createTag('p', null, caption.cloneNode(true));
+        const wrapper = createTag('div');
+        wrapper.append(picture, em);
+        row.append(wrapper);
+        caption.remove();
+      }
+  
+      block.append(row.cloneNode(true));
+      parentEl.replaceWith(block);
+    });
+  }
 }
 
 /**

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -47,6 +47,32 @@ main .inset.text-block .foreground::before {
  margin-bottom: 40px;
 }
 
+/* 
+ * Topics Header/Marquee
+*/
+
+.marquee.mini {
+  min-height: 100px;
+}
+
+.marquee.mini .foreground {
+  padding: 0;
+}
+
+.marquee.mini .foreground.container {
+  width: 100%;
+}
+
+.marquee.mini .foreground.container .text {
+  background-image: rgba(0, 0, 0, 0.8);
+  background-image: linear-gradient(to right, rgba(0,0,0,0.8), rgba(0,0,0,0));
+  box-sizing: border-box;
+  max-width: none;
+  margin: 2rem 0;
+  padding: 2rem;
+  width: 100%;
+}
+
 /*
  * Footer styles
 */


### PR DESCRIPTION
Blog topic pages have a unique/custom header. The page structure consists of an image followed by heading text (H1 or H2) as the first content on the page. This image/heading pattern was being converted in to a figure block - which didn't display correctly. 

Adding script to target topic pages only, to convert the first image and title tag to a Milo marquee.
Adding a custom variant (mini) to dial in the styling to better match what the blog styling.

**Before:**
https://main--blog--adobecom.hlx.page/en/topics/typography?martech=off
**After:**
https://topics-header--blog--adobecom.hlx.page/en/topics/typography?martech=off

Other pages to test that this change only happens on topics pages - changes shouldn't happen on these pages:
**Before:**
https://main--blog--adobecom.hlx.page/?martech=off
After:
https://topics-header--blog--adobecom.hlx.page/?martech=off

**Before:**
https://main--blog--adobecom.hlx.page/en/publish/2023/06/13/future-of-illustrator-is-here-hue-will-never-be-same?martech=off
**After:**
https://topics-header--blog--adobecom.hlx.page/en/publish/2023/06/13/future-of-illustrator-is-here-hue-will-never-be-same?martech=off