### PR TITLE
Author links 404ing

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -260,7 +260,6 @@ async function buildArticleHeader(el) {
   const tag = getMetadata('article:tag');
   const category = tag || 'News';
   const author = getMetadata('author') || 'Adobe Communications Team';
-  console.log('author', author);
   const { codeRoot } = getConfig();
   const authorURL = getMetadata('author-url') || (author ? `${codeRoot}/authors/${author.replace(/[^0-9a-z]/gi, '-').toLowerCase()}` : null);
   const publicationDate = getMetadata('publication-date');

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -261,7 +261,7 @@ async function buildArticleHeader(el) {
   const category = tag || 'News';
   const author = getMetadata('author');
   const { codeRoot } = getConfig();
-  const authorURL = getMetadata('author-url') || (author ? `${codeRoot}/authors/${author.replace(/[^0-9a-z]/gi, '-')}` : null);
+  const authorURL = getMetadata('author-url') || (author ? `${codeRoot}/authors/${author.replace(/[^0-9a-z]/gi, '-').toLowerCase()}` : null);
   const publicationDate = getMetadata('publication-date');
 
   const categoryTag = getLinkForTopic(category);

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -259,7 +259,8 @@ async function buildArticleHeader(el) {
   const picture = el.querySelector('picture');
   const tag = getMetadata('article:tag');
   const category = tag || 'News';
-  const author = getMetadata('author');
+  const author = getMetadata('author') || 'Adobe Communications Team';
+  console.log('author', author);
   const { codeRoot } = getConfig();
   const authorURL = getMetadata('author-url') || (author ? `${codeRoot}/authors/${author.replace(/[^0-9a-z]/gi, '-').toLowerCase()}` : null);
   const publicationDate = getMetadata('publication-date');


### PR DESCRIPTION
Fix author links to be lower case.

Before: https://main--blog--adobecom.hlx.page/en/publish/2023/07/27/manifest-your-career-as-an-intern?martech=off
After: https://author-link--blog--adobecom.hlx.page/en/publish/2023/07/27/manifest-your-career-as-an-intern?martech=off

To test click on the article author icon/name at the top of the page.