### PR TITLE
Topic header display bug

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -138,15 +138,17 @@ function getImageCaption(picture) {
   * Transform it into a Milo marquee with custom blog "mini" variant.
 */
 async function topicHeader(createTag) {
-  const parentEl = document.querySelector('main > div > p');
-  const imageEl = document.querySelector('main > div > p > picture');
+  const imageEl = document.querySelector('main > div:first-of-type > p > picture');
+  if(!imageEl) return;
+
+  const para = document.querySelector('main > div > p');
   const heading = document.querySelector('main > div > p + h1, main > div > p + h2, main > div > h1, main > div > h2');
   const container = createTag('div', { class: 'marquee mini'});
   const background = createTag('div', { class: 'background'}, imageEl);
   const text = createTag('div', {}, heading);
   const foreground = createTag('div', { class: 'foreground'}, text);
   container.append(background, foreground);
-  parentEl.replaceWith(container);
+  para.replaceWith(container);
 }
 
 export async function decorateContent() {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -141,12 +141,12 @@ async function topicHeader(createTag) {
   const imageEl = document.querySelector('main > div:first-of-type > p > picture');
   if(!imageEl) return;
 
-  const para = document.querySelector('main > div > p');
   const heading = document.querySelector('main > div > p + h1, main > div > p + h2, main > div > h1, main > div > h2');
   const container = createTag('div', { class: 'marquee mini'});
   const background = createTag('div', { class: 'background'}, imageEl);
   const text = createTag('div', {}, heading);
   const foreground = createTag('div', { class: 'foreground'}, text);
+  const para = document.querySelector('main > div > p');
   container.append(background, foreground);
   para.replaceWith(container);
 }


### PR DESCRIPTION
Adds a condition to check if an image is the first content on a topics page. If it is decorate the unique topics header.
* Allows authors to use other blocks as the first/top content of the page on topics pages.

Before: https://main--blog--adobecom.hlx.page/en/topics/mlb?martech=off
After: https://topic-header-bug--blog--adobecom.hlx.page/en/topics/mlb?martech=off
