### PR TITLE
Style Feds Region Picker Lang Popup

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -98,6 +98,11 @@ main .inset.text-block .foreground::before {
  * Footer styles
 */
 
+main + footer .feds-regionPicker:hover {
+  color: var(--color-gray-500);
+  border-color: var(--color-gray-500);
+  fill: var(--color-gray-500);
+}
 main + footer .footer-info {
   margin-top: 20px;
 }
@@ -106,27 +111,49 @@ main + footer .footer-region-text {
   font-size: var(--type-detail-m-size);
 }
 
-main + footer .footer-region .fragment {
+main + footer .footer-region .fragment,
+main + footer .feds-regionPicker-wrapper .fragment {
   min-width: 165px;
 }
 
-main + footer .footer-region-button.inline-dialog-active + .fragment p {
+main + footer .feds-regionPicker-wrapper > .fragment {
+  max-height: none;
+  border: 1px solid #D4D4D4;
+  box-sizing: border-box;
+}
+
+main + footer .footer-region-button.inline-dialog-active + .fragment p,
+main + footer .feds-regionPicker + .fragment p {
   font-size: var(--type-detail-l-size);
   margin-top: 20px;
   margin-bottom: 0;
 }
 
-main + footer .footer-region-button.inline-dialog-active + .fragment p:first-child {
+main + footer .footer-region-button.inline-dialog-active + .fragment p:first-child,
+main + footer .feds-regionPicker + .fragment p:first-child {
   margin-top: 0;
 }
 
-main + footer .footer-region-button.inline-dialog-active + .fragment p strong > a {
+main + footer .feds-regionPicker-wrapper > .fragment a {
+  line-height: 1;
+  padding: 0;
+  color: var(--color-gray-700);
+}
+
+main + footer .feds-regionPicker-wrapper > .fragment a:hover {
+  color: var(--color-gray-500);
+  background: none;
+}
+
+main + footer .footer-region-button.inline-dialog-active + .fragment p strong > a,
+main + footer .feds-regionPicker + .fragment p strong > a {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
-main + footer .footer-region-button.inline-dialog-active + .fragment p strong > a::after {
+main + footer .footer-region-button.inline-dialog-active + .fragment p strong > a::after,
+main + footer .feds-regionPicker-wrapper > .fragment p strong > a::after {
   content: ' ';
   display: block;
   margin: 0 2px;


### PR DESCRIPTION
Add styles for Feds footer and lang nav to match blog styling.

Before: https://main--blog--adobecom.hlx.page/?martech=off
After: https://feds-footer-styling--blog--adobecom.hlx.page/?martech=off

---
---
**Before styles applied:**
![image](https://github.com/adobecom/blog/assets/2539954/bc6d5057-e37d-46ef-9aa7-d7240b29bc23)

---
**After styles applied:**
<img width="572" alt="image" src="https://github.com/adobecom/blog/assets/2539954/d594a1eb-170c-4c39-a355-15aeafa3452c">

---
