### PR TITLE
HDR block

### DIFF
--- a/blocks/hdr/hdr.css
+++ b/blocks/hdr/hdr.css
@@ -1,0 +1,48 @@
+.hdr {
+  margin: 40px 0;
+}
+.hdr .caption {
+  margin: 5px auto 0;
+  text-align: center;
+}
+
+.hdr .hdr-container {
+  position: relative;
+}
+
+.hdr.vertical .hdr-container {
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+.hdr .hdr-container.multiple img:last-child {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.hdr .hdr-container.multiple:hover img:last-child {
+  display: block;
+  z-index: 2;
+}
+
+.hdr .hdr-container.multiple:hover:after {
+  content: 'HDR';
+  position: absolute;
+  bottom: 15px;
+  left: 10px;
+  display: block;
+  font-weight: 900;
+  font-size: 30px;
+  color: #fff;
+  z-index: 3;
+}
+
+/* Same as figure block */
+@media (min-width: 700px) {
+  .hdr .hdr-container {
+    margin: 0 auto;
+    max-width: 800px;
+  }
+}

--- a/blocks/hdr/hdr.css
+++ b/blocks/hdr/hdr.css
@@ -1,6 +1,7 @@
 .hdr {
   margin: 40px 0;
 }
+
 .hdr .caption {
   margin: 5px auto 0;
   text-align: center;

--- a/blocks/hdr/hdr.css
+++ b/blocks/hdr/hdr.css
@@ -17,14 +17,14 @@
 }
 
 .hdr .hdr-container.multiple img:last-child {
-  display: none;
+  opacity: 0;
   position: absolute;
   top: 0;
   left: 0;
 }
 
 .hdr .hdr-container.multiple:hover img:last-child {
-  display: block;
+  opacity: 1;
   z-index: 2;
 }
 

--- a/blocks/hdr/hdr.js
+++ b/blocks/hdr/hdr.js
@@ -11,7 +11,7 @@ function getMediaFilename(a) {
 };
 
 export default async function init(el) {
-  const links = el.querySelectorAll(':scope a');
+  const links = el.querySelectorAll('a[href*=".jpg"], a[href*=".png"]');
   if (!links.length) return;
 
   const { createTag } = await import(`${getLibs()}/utils/utils.js`);
@@ -19,24 +19,22 @@ export default async function init(el) {
   const container = createTag('div', { class: 'hdr-container' }, null);
   el.innerHTML = '';
 
-  if(links.length > 1) {
+  if (links.length > 1) {
     container.classList.add('multiple');
   }
   el.append(container);
 
   links.forEach((link) => {
-    const img = document.createElement('img');
+    const img = createTag('img', { loading: 'lazy' }, null);
 
     img.src = getMediaFilename(link);
-    img.setAttribute('loading', 'lazy');
     container.append(img);
     link.remove();
   });
 
-  if(!caption) return;
-  const para = document.createElement('p');
+  if (!caption) return;
+  const para = createTag('p', { class: 'caption'}, null);
 
-  para.classList.add('caption');
   para.append(caption);
   el.append(para);
 }

--- a/blocks/hdr/hdr.js
+++ b/blocks/hdr/hdr.js
@@ -1,0 +1,42 @@
+import { getLibs } from '../../scripts/utils.js';
+
+function getMediaFilename(a) {
+  try {
+    const mediaUrl = new URL(a.href);
+    return mediaUrl.pathname;
+  } catch (e) {
+    console.log('Error parsing media url', e);
+  }
+  return '';
+};
+
+export default async function init(el) {
+  const links = el.querySelectorAll(':scope a');
+  if (!links.length) return;
+
+  const { createTag } = await import(`${getLibs()}/utils/utils.js`);
+  const caption = el.querySelector(':scope em');
+  const container = createTag('div', { class: 'hdr-container' }, null);
+  el.innerHTML = '';
+
+  if(links.length > 1) {
+    container.classList.add('multiple');
+  }
+  el.append(container);
+
+  links.forEach((link) => {
+    const img = document.createElement('img');
+
+    img.src = getMediaFilename(link);
+    img.setAttribute('loading', 'lazy');
+    container.append(img);
+    link.remove();
+  });
+
+  if(!caption) return;
+  const para = document.createElement('p');
+
+  para.classList.add('caption');
+  para.append(caption);
+  el.append(para);
+}


### PR DESCRIPTION
New HDR block to support HDR images

* Display HDR images
* Supports before and after images that swap on hover.

Resolves: [MWPW-136514](https://jira.corp.adobe.com/browse/MWPW-136514)

**Test URLs:**
* Before: https://main--blog--adobecom.hlx.page/en/drafts/rclayton/hdr-explained?martech=off
* After: https://hdr--blog--adobecom.hlx.page/en/drafts/rclayton/hdr-explained?martech=off