### PR TITLE
Decorate video

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -114,10 +114,11 @@ function decorateVideo() {
   videoBlocks.forEach((block) => {
     const link = block.querySelector(':scope a');
     const videoCaption = block.querySelector(':scope p:last-of-type');
-    const url = block.classList.contains('autoplay') || block.classList.contains('animation')
-      ? `${link.href}#_autoplay`
-      : link.href;
     const para = document.createElement('p');
+    const url = block.classList.contains('autoplay') || block.classList.contains('animation')
+      ? `${link?.href}#_autoplay`
+      : link?.href;
+    if (!url) return;
 
     link.href = url;
     para.append(link);


### PR DESCRIPTION
Adds a check for url/link. 

If no url/link is detected do an early return so the page is rendered with a notice of block failing.

**Testing URLs**
Before: https://main--blog--adobecom.hlx.page/en/drafts/rclayton/behind-the-adobe-social-channels-for-max?martech=off
After: https://video-blocking--blog--adobecom.hlx.page/en/drafts/rclayton/behind-the-adobe-social-channels-for-max?martech=off