### PR TITLE
Tab mobile content alignment

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -199,3 +199,11 @@ main + footer .feds-regionPicker-wrapper > .fragment p strong > a::after {
     height: 784px;
  }
 }
+
+@media screen and (max-width: 1200px) {
+  .tab-content .section[class*='grid-width-'] {
+    justify-content: center;
+    padding-left: inherit;
+    padding-right: inherit;
+  }
+}


### PR DESCRIPTION
Temp fix while this gets fixed properly in Milo. 
The main cause appears to be related to [section-metadata.css](https://github.com/adobecom/milo/blob/main/libs/blocks/section-metadata/section-metadata.css#L170-L175)


* Fixes issue with tab content in mobile viewports being mis-aligned.

**Test URLs**
* Before: https://main--blog--adobecom.hlx.page/en/topics/nwsl?martech=off
* After: https://tab-content-alignment--blog--adobecom.hlx.page/en/topics/nwsl?martech=off

**Testing notes:**
1. Pull up the test pages.
2. Open developer tools and enable device toolbar to see the different devices options/breakpoints
3. View content from the page in the Tabs, just below the top marquee. Content is mis-aligned and pushing off screen.