### PR TITLE
add support to remove section margin

### DIFF
--- a/styles/articles.css
+++ b/styles/articles.css
@@ -12,8 +12,12 @@ main h1, main h2, main h3, main h4, main h5, main h6 {
   scroll-margin-top: 90px;
 }
 
-main .section{
+main .section:not(.no-margin-top){
   margin-top: 64px
+}
+
+main .section.no-margin {
+  margin: 0;
 }
 
 main .figure .figure img {


### PR DESCRIPTION
Margin top is added in section which creates unwanted margin-top in some cases. This will allow us to remove that margin using `no margin top` or `no margin` in `section-metadata`.

Before: https://main--blog--adobecom.hlx.page/en/drafts/smalla/adobe-sundance-test
After: https://section-metadata--blog--adobecom.hlx.page/en/drafts/smalla/adobe-sundance

<img width="2535" alt="Screenshot 2023-12-05 at 3 58 49 PM" src="https://github.com/adobecom/blog/assets/25802201/d17ae49b-e49e-409a-bcfa-93ddf3216aa0">
