### PR TITLE
chore: add review and live hosts

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,6 +1,8 @@
 {
   "project": "Blog",
   "host": "blog.adobe.com",
+  "reviewHost": "main--blog--adobecom.aem.page",
+  "liveHost": "main--blog--adobecom.aem.live",
   "plugins": [
     {
       "id": "library",


### PR DESCRIPTION
adding review and live hosts to reflect `aem.page` and `aem.live`

https://main--blog--adobecom.hlx.page/

vs.

https://helix5-hosts--blog--adobecom.hlx.page/
