### PR TITLE
Update config.json

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -3,6 +3,17 @@
   "host": "blog.adobe.com",
   "plugins": [
     {
+      "id": "path",
+      "title": "Path",
+      "environments": [ "edit" ],
+      "url": "https://milo.adobe.com/tools/path-finder",
+      "isPalette": true,
+      "passReferrer": true,
+      "passConfig": true,
+      "paletteRect": "top: 50%; left: 50%; transform: translate(-50%,-50%); height: 84px; width: 900px; overflow: hidden; border-radius: 6px; box-shadow: 0 20px 35px 0px rgba(0, 0, 0, 0.5);",
+      "includePaths": [ "**.docx**", "**.xlsx**" ]
+    },
+    {
       "id": "library",
       "title": "Library",
       "environments": [ "edit" ],


### PR DESCRIPTION
Add path finder tool to sidekick.

* Adding path finder tool to sidekick.

**Test URLs:**
- Before: https://main--blog--adobecom.hlx.live/?martech=off
- After: https://rgclayton-patch-1--blog--adobecom.hlx.live?martech=off

Added to Milo this week.

1. Access from any Word/Excel page.
2. Open sidekick
3. Click "path" button in sidekick (top level).
4. Launches the path tool.
5. Lists the relative (human readable) path for the Word/Excel doc.
6. Can modify the path to jump to a new Word/Excel doc.
7. Options include opening the path in same page or in a new tab