### PR TITLE
[MWPW 151457] Added stage domains map to make links environment-aware

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -44,6 +44,12 @@ const CONFIG = {
     'en/uk': { ietf: 'en', tk: 'hah7vzn.css' },
     'en/apac': { ietf: 'en', tk: 'hah7vzn.css' },
   },
+  stageDomainsMap: {
+    'blog.adobe.com': 'blog.stage.adobe.com',
+    'news.adobe.com': 'news.stage.adobe.com',
+    'business.adobe.com': 'business.stage.adobe.com',
+    'www.adobe.com': 'www.stage.adobe.com'
+  }
 };
 
 // Milo blocks overridden by the Blog project

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -48,7 +48,7 @@ const CONFIG = {
     'blog.adobe.com': 'blog.stage.adobe.com',
     'news.adobe.com': 'news.stage.adobe.com',
     'business.adobe.com': 'business.stage.adobe.com',
-    'www.adobe.com': 'www.stage.adobe.com'
+    'www.adobe.com': 'www.stage.adobe.com',
   }
 };
 


### PR DESCRIPTION
**Description**
This PR adds the `stageDomainsMap` to the config allowing links to be environment-aware.
More about this new feature can be found in [here](https://github.com/orgs/adobecom/discussions/2437).

Resolves: [MWPW-151457](https://jira.corp.adobe.com/browse/MWPW-151457)