### PR TITLE
[MWPW-150667] - milolibs query parameter not working

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -19,7 +19,7 @@ export const [setLibs, getLibs] = (() => {
     (prodLibs, location) => {
       libs = (() => {
         const { hostname, search } = location || window.location;
-        if (!(hostname.includes('.hlx.') || hostname.includes('local'))) return prodLibs;
+        if (!['.hlx.', '.stage.', 'local'].some((i) => hostname.includes(i))) return prodLibs;
         const branch = new URLSearchParams(search).get('milolibs') || 'main';
         if (branch === 'local') return 'http://localhost:6456/libs';
         return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;


### PR DESCRIPTION
### Description:
This PR extends the nonprod hostnames check that determines if the milolibs query parameter is allowed.

### Resolves: 
https://jira.corp.adobe.com/browse/MWPW-150667

### Test URLs:
- Before: https://main--blog--adobecom.hlx.page/
- After: https://main--blog--adobecom.hlx.page/?milolibs=darth-vader--milo--robert-bogos
