### PR TITLE
Bug with getImageCaption

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -121,7 +121,7 @@ function getImageCaption(picture) {
     && !parentSiblingEl.querySelector('picture')
     && parentSiblingEl.firstChild?.tagName === 'EM'
     ? parentSiblingEl.querySelector('em')
-    : undefined;
+    : '';
   return caption;
 }
 


### PR DESCRIPTION
Found as part of https://jira.corp.adobe.com/browse/MWPW-146743, there is an instance where `caption` will equal `undefined` and be appended to the DOM. Although there are checks for `caption`, if undefined is stored as a value, it can be appended to the DOM. 

Note, this is an edge case that only occurs under the condition that whatever code runs does not remove the last children of the DOM sent with picture elements. In most instances, we do this removal, but better to remove the bug where it is instead of finding it later.  

Before: https://main--blog--adobecom.hlx.page/en/publish/2024/05/21/lightroom-introduces-power-adobe-firefly-with-generative-remove?milolibs=get-image-caption-undefined-issue
After: https://fix-get-image-caption--blog--adobecom.hlx.page/en/publish/2024/05/21/lightroom-introduces-power-adobe-firefly-with-generative-remove?milolibs=get-image-caption-undefined-issue