### PR TITLE
Add helix-5 support for blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Developing
 1. Install the [Helix CLI](https://github.com/adobe/helix-cli): `sudo npm install -g @adobe/helix-cli`
-1. Run `hlx up` this repo's folder. (opens your browser at `http://localhost:3000`)
+1. Run `aem up` this repo's folder. (opens your browser at `http://localhost:3000`)
 1. Open this repo's folder in your favorite editor and start coding.
 
 ## Testing

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -48,16 +48,7 @@ const CONFIG = {
     'blog.stage.adobe.com': {
       'blog.adobe.com': 'origin',
     },
-    '--blog--adobecom.hlx.live': {
-      'blog.adobe.com': 'origin',
-    },
-    '--blog--adobecom.hlx.page': {
-      'blog.adobe.com': 'origin',
-    },
-    '--blog--adobecom.aem.live': {
-      'blog.adobe.com': 'origin',
-    },
-    '--blog--adobecom.aem.page': {
+    '^https://.*--blog--.*.(hlx|aem).(page|live)': {
       'blog.adobe.com': 'origin',
     },
   },

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -54,6 +54,12 @@ const CONFIG = {
     '--blog--adobecom.hlx.page': {
       'blog.adobe.com': 'origin',
     },
+    '--blog--adobecom.aem.live': {
+      'blog.adobe.com': 'origin',
+    },
+    '--blog--adobecom.aem.page': {
+      'blog.adobe.com': 'origin',
+    },
   },
 };
 

--- a/scripts/sidekick.js
+++ b/scripts/sidekick.js
@@ -1,6 +1,6 @@
 import predictUrl from '../tools/sidekick/predicturl/predicturl.js';
 
 (async function init() {
-  const sk = document.querySelector('helix-sidekick');
+  const sk = document.querySelector('aem-sidekick, helix-sidekick');
   sk.addEventListener('custom:predicted-url', predictUrl);
 }());

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -19,10 +19,10 @@ export const [setLibs, getLibs] = (() => {
     (prodLibs, location) => {
       libs = (() => {
         const { hostname, search } = location || window.location;
-        if (!(hostname.includes('.hlx.') || hostname.includes('local'))) return prodLibs;
+        if (!(hostname.includes('.aem.') || hostname.includes('.hlx.') || hostname.includes('local'))) return prodLibs;
         const branch = new URLSearchParams(search).get('milolibs') || 'main';
         if (branch === 'local') return 'http://localhost:6456/libs';
-        return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;
+        return branch.includes('--') ? `https://${branch}.aem.live/libs` : `https://${branch}--milo--adobecom.aem.live/libs`;
       })();
       return libs;
     }, () => libs,

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,8 +1,6 @@
 {
   "project": "Blog",
   "host": "blog.adobe.com",
-  "previewHost": "main--blog--adobecom.aem.page",
-  "liveHost": "main--blog--adobecom.aem.live",
   "plugins": [
     {
       "id": "path",

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,6 +1,8 @@
 {
   "project": "Blog",
   "host": "blog.adobe.com",
+  "previewHost": "main--blog--adobecom.aem.page",
+  "liveHost": "main--blog--adobecom.aem.live",
   "plugins": [
     {
       "id": "path",
@@ -33,7 +35,7 @@
       "title": "Tag Selector",
       "id": "tag-selector",
       "environments": ["edit"],
-      "url": "https://main--blog--adobecom.hlx.live/tools/tagger",
+      "url": "https://main--blog--adobecom.aem.live/tools/tagger",
       "isPalette": true,
       "paletteRect": "top: 150px; left: 7%; height: 675px; width: 85vw;"
     },
@@ -67,7 +69,7 @@
       "title": "Localize project",
       "environments": [ "edit" ],
       "passConfig": true,
-      "url": "https://locui--milo--adobecom.hlx.page/tools/loc",
+      "url": "https://locui--milo--adobecom.aem.page/tools/loc",
       "passReferrer": true,
       "excludePaths": [ "/**" ],
       "includePaths": [ "**/:x**" ]


### PR DESCRIPTION
### Description
Support both .hlx. and .aem.

### Test instructions
No regressions on https://hlx-5--blog--adobecom.hlx.page/ AND https://hlx-5--blog--adobecom.aem.page/ (and .live)

### Test links
Before: https://main--blog--adobecom.hlx.page/
After: https://hlx-5--blog--adobecom.hlx.page/
After-2: https://hlx-5--blog--adobecom.aem.page/