### PR TITLE
Add a security query index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -91,3 +91,9 @@ indices:
     include:
       - /ko/publish/*/*/*/*
     target: /ko/query-index.xlsx
+
+  security:
+    <<: *default
+    include:
+      - /security/*
+    target: /security-query-index.xlsx


### PR DESCRIPTION
### Description
Adds a "security-query-index" that pulls in all security related articles. The test page below, would then consume this index to create the article-feed.

### Test instructions
This is untested and I don't have a good idea on how to test this outside of stage. There are no published security related articles either that would then go into this index for now 🤷 Ideas how to test this welcome. Otherwise I'd suggest we test this on stage, since this is the new base-branch this should properly create the index on stage.

Before/after: 
- https://stage--blog--adobecom.aem.page/security/drafts/osahin/
- https://add-security-query-index--blog--adobecom.aem.page/security/drafts/osahin/