### PR TITLE
Sync stage and main

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -95,5 +95,5 @@ indices:
   security:
     <<: *default
     include:
-      - /security/*
+      - /security/**
     target: /security-query-index.xlsx


### PR DESCRIPTION
### Description
Add a 'security' index to the blog in preparation for migrating the security related articles.

Changes to the index will only work locally and I've tested this with `aem up --print-index` to ensure the articles properly match the index.
```
info: Index information for /security/2024/bts-cristina-nica
info: Index: security
info:         author: "Renae Kang"
info:          title: "Behind the Scenes with Cristina, Manager of Information Security"
info:           date: 45147
info:          image: "/security/2024/media_174446933452361fcd8d016a3132d0bb3e82171c7.png?width=1200&format=pjpg&optimize=medium"
info:       imageAlt: ""
info:    description: "As a global leader in the cybersecurity space, Adobe recognizes that great cybersecurity talent can come from anywhere, and we actively seek to leverage the skills and perspectives of those who come…"
info:           tags: ["Security"]
info:         robots: ""
info:   lastModified: ""
```

Before/After
- https://main--blog--adobecom.aem.page/security/drafts/osahin/
- https://stage--blog--adobecom.aem.page/security/drafts/osahin/