### PR TITLE
Add security index to the sitemap

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -45,3 +45,12 @@ sitemaps:
         destination: /br/sitemap.xml
         hreflang: pt
         alternate: /br/{path}
+  security-blog:
+    origin: https://blog.adobe.com
+    lastmod: YYYY-MM-DD
+    languages:
+      en:
+        source: /security-query-index.json?sheet=sitemap
+        destination: /en/sitemap.xml
+        hreflang: en
+        alternate: /en/{path}


### PR DESCRIPTION
Add the new [security related articles](https://blog.adobe.com/security-query-index.json?sheet=sitemap) to the [sitemap](https://blog.adobe.com/en/sitemap.xml) for blog.adobe.com. 

As per the [sitemap docs](https://www.aem.live/developer/sitemap#multiple-indexes-aggregated-into-one-sitemap) we can aggregate multiple indexes into the english sitemap.
> There are cases where it is easier to have a single larger sitemap than fragmented small sitemaps, especially as there is a limit of sitemaps that can be submitted to search engines per site.

As far as I'm aware, we can't test this locally.. Link for the aem-code-sync PSI check:
- https://add-to-sitemap--blog--adobecom.hlx.page/