### PR TITLE
feat: Use CSP for scripts with (cached) nonce + strict-dynamic

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,12 +1,17 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';"
+      move-as-header="true"
+    >
     <title>404</title>
     <meta name="template" content="404"/>
     <meta name="404" content="local"/>
     <meta name="footer" content="global-footer"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <script src="/scripts/scripts.js" type="module"></script>
+    <script nonce="aem" src="/scripts/scripts.js" type="module"></script>
     <link rel="icon" href="data:,">
     </head>
   <body>

--- a/head.html
+++ b/head.html
@@ -1,4 +1,9 @@
+<meta
+  http-equiv="Content-Security-Policy"
+  content="script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';"
+  move-as-header="true"
+>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<script src="/scripts/scripts.js" type="module"></script>
+<script nonce="aem" src="/scripts/scripts.js" type="module"></script>
 <style>body { display: none; }</style>
 <link rel="icon" href="data:,">


### PR DESCRIPTION
Ticket https://jira.corp.adobe.com/browse/MWPW-169753

Test URL:
* https://strictdynamic--blog--adobecom.aem.live/

For more details on the CSP, please checkout:
* https://github.com/adobe/helix-html-pipeline/pull/816
* https://content-security-policy.com/strict-dynamic/
If you would prefer to use the headers config, rather than putting the meta tag in code, that is supported too. I used this mechanism because it allows testing on a branch, without impacting anything else. The `nonce="aem"` on the script tags however needs to be preserved in code.

From the quick tests I did by clicking around the blog, I didn't see any CSP violation error.
I see either the same errors from the `stage` branch or CORS errors from IMS, which should be unrelated.