### PR TITLE
chore: Configure Trusted Hosts for Sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,6 +1,7 @@
 {
   "project": "Blog",
   "host": "blog.adobe.com",
+  "trustedHosts": ["milo.adobe.com", "*--milo--adobecom.aem.page"],
   "plugins": [
     {
       "id": "path",


### PR DESCRIPTION
Please double check that `trustedHosts` matches the urls of the loaded plugins.
Thank you!