### PR TITLE
fix: Rename "move-as-header" to "move-to-http-header"

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,7 +4,7 @@
     <meta
       http-equiv="Content-Security-Policy"
       content="script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';"
-      move-as-header="true"
+      move-to-http-header="true"
     >
     <title>404</title>
     <meta name="template" content="404"/>

--- a/head.html
+++ b/head.html
@@ -1,7 +1,7 @@
 <meta
   http-equiv="Content-Security-Policy"
   content="script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';"
-  move-as-header="true"
+  move-to-http-header="true"
 >
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <script nonce="aem" src="/scripts/scripts.js" type="module"></script>


### PR DESCRIPTION
The attribute has been renamed to make it more clear.

Before: https://main--blog--adobecom.aem.live
After: https://move-to-http-header--blog--adobecom.aem.live