### PR TITLE
MWPW-178159: Fix empty figure and spacing

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -229,9 +229,9 @@ const { loadArea, setConfig, getMetadata } = await import(`${miloLibs}/utils/uti
   decorateVideo();
   decorateQuote();
   decorateGif();
-  await decorateContent();
   setConfig({ ...CONFIG, miloLibs });
   await buildAutoBlocks();
+  await decorateContent();
   overrideMiloBlocks();
   await loadArea();
   initSidekick();

--- a/styles/articles.css
+++ b/styles/articles.css
@@ -12,15 +12,35 @@ main h1, main h2, main h3, main h4, main h5, main h6 {
   scroll-margin-top: 90px;
 }
 
+.content:has(+ .figure) > :last-child {
+  margin-bottom: 0;
+}
+
+.figure + .content > :first-child {
+  margin-top: 0;
+}
+
+.figure + .content > :is(h1, h2, h3, h4, h5, h6):first-child {
+  margin-top: 8px;
+}
+
+.section .figure:first-child {
+  padding-top: 0;
+}
+
+.section .figure:last-child {
+  padding-bottom: 0;
+}
+
 main .section{
   margin-top: 64px
 }
 
-main .figure .figure img {
+main .figure figure img {
   object-fit: contain;
 }
 
-main .figure .figure .infograph,
+main .figure figure .infograph,
 main .article-header .article-category,
 main .article-header .article-title,
 main .article-header .article-byline {
@@ -35,6 +55,22 @@ main video {
 }
 
 @media (min-width: 700px) {
+  .figure.figure-list + .content > :first-child:not(h1, h2, h3, h4, h5, h6) {
+    margin-top: revert;
+  }
+
+  .content:has(+ .figure.figure-list) > :last-child:not(h1, h2, h3, h4, h5, h6) {
+    margin-bottom: revert;
+  }
+
+  .figure.figure-list + .content > :is(h1, h2, h3, h4, h5, h6):first-child {
+    margin-top: 48px;
+  }
+
+  .content:has(+ .figure.figure-list) > :is(h1, h2, h3, h4, h5, h6):last-child {
+    margin-bottom: 16px;
+  }
+
   main .section > div > :not(div):not(h1),
   main .section > .tags,
   main .columns, main .columns.contained {


### PR DESCRIPTION
Issue: Empty figure block is added to a page resulting in additional space between elements.

- Prevent empty `figure` block from being created
- Fix spacing issues between `figure` block and other elements on the page

Resolves: [MWPW-178159](https://jira.corp.adobe.com/browse/MWPW-178159)

**Test URLs:**
- Before: https://main--blog--adobecom.aem.page/en/drafts/ratko/test-blog?martech=off
- After: https://mwpw-178159-empty-figure--blog--adobecom.aem.page/en/drafts/ratko/test-blog?martech=off
- Before: https://main--blog--adobecom.aem.page/en/drafts/julia/empowering-nonprofits-to-tell-their-stories-celebrating-national-nonprofit-day-with-adobe?martech=off
- After: https://mwpw-178159-empty-figure--blog--adobecom.aem.page/en/drafts/julia/empowering-nonprofits-to-tell-their-stories-celebrating-national-nonprofit-day-with-adobe?martech=off

**Link with reverted Milo PR [*4634*](https://github.com/adobecom/milo/pull/4634) that caused the issue for reference:**
https://main--blog--adobecom.aem.page/en/drafts/ratko/test-blog?milolibs=reverted-4634

**NOTE:** This spacing issue will be fixed by the Milo PR [4723](https://github.com/adobecom/milo/pull/4723)
<img width="886" height="482" alt="Screenshot 2025-08-14 at 11 32 06" src="https://github.com/user-attachments/assets/9cd02302-0ffa-4bf3-ae78-26b7ef0cf881" />

<img width="854" height="481" alt="Screenshot 2025-08-14 at 11 32 19" src="https://github.com/user-attachments/assets/a44b2928-d19b-4ec1-b16b-867563f2eea1" />

Link: https://mwpw-178159-empty-figure--blog--adobecom.aem.page/en/drafts/ratko/test-blog?martech=off&milolibs=figure-padding-fix

